### PR TITLE
GitButler Workspace Commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
-        bundler-cache: false
+        ruby-version: "3.2.5"
+        bundler-cache: true
     - name: Bundle Install
       run: bundle install
       env:


### PR DESCRIPTION
This is a merge commit the virtual branches in your workspace.

Due to GitButler managing multiple virtual branches, you cannot switch back and forth between git branches and virtual branches easily. 

If you switch to another branch, GitButler will need to be reinitialized. If you commit on this branch, GitButler will throw it away.

Here are the branches that are currently applied:
 - Update der just-the-docs Version (refs/gitbutler/Update-der-just-the-docs-Version) branch head: d1c0d23b1c93897114d4d5175de631b230dc218e
 - Virtual branch (refs/gitbutler/Virtual-branch)
   - Gemfile.lock
 - Update des Gemflie.lock (refs/gitbutler/Update-des-Gemflie.lock) For more information about what we're doing here, check out our docs: https://docs.gitbutler.com/features/virtual-branches/integration-branch